### PR TITLE
QuizActivity. Fixed multiple back-presses crash.

### DIFF
--- a/app/src/main/java/com/google/samples/apps/topeka/activity/QuizActivity.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/activity/QuizActivity.java
@@ -132,6 +132,8 @@ public class QuizActivity extends Activity {
                 new AnimatorListenerAdapter() {
                     @Override
                     public void onAnimationEnd(Animator animation) {
+                        if (isFinishing() || isDestroyed())
+                            return;
                         QuizActivity.super.onBackPressed();
                         super.onAnimationEnd(animation);
                     }


### PR DESCRIPTION
The crash happens when you are clicking back button multiple times on QuizActivity:

06-27 14:59:28.118 20773-20773/? E/AndroidRuntime﹕ FATAL EXCEPTION: main
Process: com.google.samples.apps.topeka, PID: 20773
java.lang.NullPointerException: Attempt to read from field 'android.os.Handler android.app.Activity.mHandler' on a null object reference
at android.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:1427)
at android.app.FragmentManagerImpl.executePendingTransactions(FragmentManager.java:483)
at android.app.FragmentManagerImpl.popBackStackImmediate(FragmentManager.java:498)
at android.app.Activity.onBackPressed(Activity.java:2479)
at com.google.samples.apps.topeka.activity.QuizActivity.access$201(QuizActivity.java:42)
at com.google.samples.apps.topeka.activity.QuizActivity$2.onAnimationEnd(QuizActivity.java:135)
at android.view.ViewPropertyAnimator$AnimatorEventListener.onAnimationEnd(ViewPropertyAnimator.java:1116)
at android.animation.ValueAnimator.endAnimation(ValueAnimator.java:1089)
at android.animation.ValueAnimator$AnimationHandler.doAnimationFrame(ValueAnimator.java:666)
at android.animation.ValueAnimator$AnimationHandler.run(ValueAnimator.java:682)
at android.view.Choreographer$CallbackRecord.run(Choreographer.java:767)
at android.view.Choreographer.doCallbacks(Choreographer.java:580)
at android.view.Choreographer.doFrame(Choreographer.java:549)
at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:753)
at android.os.Handler.handleCallback(Handler.java:739)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:135)
at android.app.ActivityThread.main(ActivityThread.java:5254)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:898)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:693)
