### PR TITLE
Fix AnswerHelper.isAnswerCorrect method and android test

### DIFF
--- a/app/src/androidTest/java/com/google/samples/apps/topeka/helper/AnswerHelperTest.java
+++ b/app/src/androidTest/java/com/google/samples/apps/topeka/helper/AnswerHelperTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class AnswerHelperTest {
 
     private static final int[] OPTIONS = new int[]{0, 1, 2};
-    private int[] WRONG_OPTIONS = new int[]{2, 3};
+    private int[] WRONG_OPTIONS = new int[]{2, 1};
     private SparseBooleanArray mCorrectAnswer;
 
     @Before

--- a/app/src/main/java/com/google/samples/apps/topeka/helper/AnswerHelper.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/helper/AnswerHelper.java
@@ -85,7 +85,7 @@ public class AnswerHelper {
                 return false;
             }
         }
-        return true;
+        return checkedItems.size() == answerIds.length;
     }
 
 }


### PR DESCRIPTION
Fixes #40 "Check all the items is always considered a correct answer due bug...".

The wrong choices are no longer ignored when all the correct answers are checked
and one test checks it.