### PR TITLE
FIXED: Floating label overlaps username last initial on S2 API 19 (4.4.4) #44

### DIFF
--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -14,14 +14,13 @@
   ~ limitations under the License.
   -->
 
-<FrameLayout
-    android:id="@+id/sign_in_container"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
              xmlns:tools="http://schemas.android.com/tools"
+             android:id="@+id/sign_in_container"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
-    android:background="@color/light_grey"
-    android:padding="@dimen/spacing_double"
-    android:transitionGroup="false"
              tools:context="activity.SignInActivity"
+    android:background="@color/light_grey"
+    android:transitionGroup="false"
+    android:padding="@dimen/spacing_double"
     tools:ignore="MergeRootFrame,Overdraw,UnusedAttribute"/>

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -14,12 +14,14 @@
   ~ limitations under the License.
   -->
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    android:id="@+id/sign_in_container"
+    xmlns:android="http://schemas.android.com/apk/res/android"
              xmlns:tools="http://schemas.android.com/tools"
-             android:id="@+id/sign_in_container"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
+    android:background="@color/light_grey"
+    android:padding="@dimen/spacing_double"
+    android:transitionGroup="false"
              tools:context="activity.SignInActivity"
-             android:background="@color/light_grey"
-             android:transitionGroup="false"
-             tools:ignore="MergeRootFrame,Overdraw,UnusedAttribute" />
+    tools:ignore="MergeRootFrame,Overdraw,UnusedAttribute"/>

--- a/app/src/main/res/layout/sign_in_username.xml
+++ b/app/src/main/res/layout/sign_in_username.xml
@@ -15,66 +15,67 @@
   -->
 
 <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        tools:showIn="@layout/fragment_sign_in">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:showIn="@layout/fragment_sign_in">
 
     <TextView
-            android:id="@+id/toolbar_sign_in"
-            android:layout_width="match_parent"
-            android:layout_height="?android:attr/actionBarSize"
-            style="@style/Topeka.TextAppearance.Title"
-            android:elevation="@dimen/elevation_header"
-            android:gravity="center_vertical"
-            android:text="@string/sign_in"
-            android:paddingEnd="@dimen/spacing_double"
-            android:paddingStart="@dimen/spacing_double"
-            android:clipToPadding="false"
-            tools:ignore="UnusedAttribute,NewApi" />
+        android:id="@+id/toolbar_sign_in"
+        style="@style/Topeka.TextAppearance.Title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:elevation="@dimen/elevation_header"
+        android:paddingEnd="@dimen/spacing_double"
+        android:paddingStart="@dimen/spacing_double"
+        android:text="@string/sign_in"
+        tools:ignore="UnusedAttribute,NewApi"/>
 
     <android.support.design.widget.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/spacing_micro"
+        android:paddingEnd="@dimen/spacing_double"
+        android:paddingStart="@dimen/spacing_double"
+        android:paddingTop="@dimen/spacing_micro"
+        android:transitionGroup="true"
+        tools:ignore="UnusedAttribute,NewApi">
+
+        <EditText
+            android:id="@+id/first_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingStart="@dimen/spacing_double"
-            android:paddingTop="@dimen/spacing_micro"
-            android:paddingEnd="@dimen/spacing_double"
-            android:paddingBottom="@dimen/spacing_micro"
-            android:clipToPadding="false"
-            android:transitionGroup="true"
-            tools:ignore="UnusedAttribute,NewApi">
-        <EditText
-                android:id="@+id/first_name"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/first_name"
-                android:imeOptions="actionNext"
-                android:inputType="textCapWords"
-                android:minHeight="?android:attr/actionBarSize"
-                android:textSize="@dimen/size_edit_text" />
+            android:hint="@string/first_name"
+            android:imeOptions="actionNext"
+            android:inputType="textCapWords"
+            android:minHeight="?android:attr/actionBarSize"
+            android:textSize="@dimen/size_edit_text"/>
     </android.support.design.widget.TextInputLayout>
 
     <android.support.design.widget.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/spacing_micro"
+        android:paddingEnd="@dimen/spacing_double"
+        android:paddingStart="@dimen/spacing_double"
+        android:paddingTop="@dimen/spacing_micro"
+        android:transitionGroup="true"
+        tools:ignore="UnusedAttribute,NewApi">
+
+        <EditText
+            android:id="@+id/last_initial"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingStart="@dimen/spacing_double"
-            android:paddingTop="@dimen/spacing_micro"
-            android:paddingEnd="@dimen/spacing_double"
-            android:paddingBottom="@dimen/spacing_micro"
-            android:clipToPadding="false"
-            android:transitionGroup="true"
-            tools:ignore="UnusedAttribute,NewApi">
-        <EditText
-                android:id="@+id/last_initial"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/last_initial"
-                android:imeOptions="actionDone"
-                android:inputType="textNoSuggestions|textCapWords"
-                android:maxLength="1"
-                android:minHeight="?android:attr/actionBarSize"
-                android:textSize="@dimen/size_edit_text" />
+            android:hint="@string/last_initial"
+            android:imeOptions="actionDone"
+            android:inputType="textNoSuggestions|textCapWords"
+            android:maxLength="1"
+            android:minHeight="?android:attr/actionBarSize"
+            android:textSize="@dimen/size_edit_text"/>
     </android.support.design.widget.TextInputLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/sign_in_username.xml
+++ b/app/src/main/res/layout/sign_in_username.xml
@@ -24,14 +24,14 @@
 
     <TextView
         android:id="@+id/toolbar_sign_in"
-        style="@style/Topeka.TextAppearance.Title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:clipToPadding="false"
+        style="@style/Topeka.TextAppearance.Title"
         android:elevation="@dimen/elevation_header"
+        android:text="@string/sign_in"
         android:paddingEnd="@dimen/spacing_double"
         android:paddingStart="@dimen/spacing_double"
-        android:text="@string/sign_in"
+        android:clipToPadding="false"
         tools:ignore="UnusedAttribute,NewApi"/>
 
     <android.support.design.widget.TextInputLayout


### PR DESCRIPTION
Hi,

according to unsolved issue with small screen devices, I decided to fixed it in the best way I can.
After reading #44 issue, I run my Genymotion emulator: Samsung S2 - 4.1.1 - API 16, 480x800, 240dpi.

The login activity wasn't good looking as I excepted: 
<strong>BEFORE CHANGES:</strong>
<a href="http://pl.tinypic.com?ref=2ahz6uo" target="_blank"><img src="http://i68.tinypic.com/2ahz6uo.png" border="0" alt="Image and video hosting by TinyPic" height="450"></a>&nbsp;&nbsp;<a href="http://pl.tinypic.com?ref=13zycms" target="_blank"><img src="http://i66.tinypic.com/13zycms.png" border="0" alt="Image and video hosting by TinyPic" height="450"></a>

After putting a few small changes the look of sign in activity is:
<strong>AFTER CHANGES:</strong>
<a href="http://pl.tinypic.com?ref=o8yk38" target="_blank"><img src="http://i68.tinypic.com/o8yk38.png" border="0" alt="Image and video hosting by TinyPic" height="450"></a>&nbsp;&nbsp;<a href="http://pl.tinypic.com?ref=tarho6" target="_blank"><img src="http://i64.tinypic.com/tarho6.png" border="0" alt="Image and video hosting by TinyPic" height="450"></a>

Some more useful information about improving layout on devices with older version of Android: #47 

Wish this would help.
Cheers.