### PR TITLE
Fix SignIn fragment and tests and consider all the player preferences required

### DIFF
--- a/app/src/androidTest/java/com/google/samples/apps/topeka/activity/SignInActivityTest.java
+++ b/app/src/androidTest/java/com/google/samples/apps/topeka/activity/SignInActivityTest.java
@@ -57,6 +57,7 @@ public class SignInActivityTest {
 
     private static final String TEST_FIRST_NAME = "Zaphod";
     private static final String TEST_LAST_INITIAL = "B";
+    private static final Avatar TEST_AVATAR = Avatar.TWELVE;
 
     @Rule
     public ActivityTestRule<SignInActivity> mActivityRule =
@@ -82,13 +83,32 @@ public class SignInActivityTest {
     }
 
     @Test
-    public void signIn_inputDataSuccessfully() {
-        inputData();
+    public void signIn_withoutFirstNameFailed() {
+        inputData(null, TEST_LAST_INITIAL, TEST_AVATAR);
+        onView(withId(R.id.done)).check(matches(not(isDisplayed())));
+    }
+
+    @Test
+    public void signIn_withoutLastInitialFailed() {
+        inputData(TEST_FIRST_NAME, null, TEST_AVATAR);
+        onView(withId(R.id.done)).check(matches(not(isDisplayed())));
+    }
+
+    @Test
+    public void signIn_withoutAvatarFailed() {
+        inputData(TEST_FIRST_NAME, TEST_LAST_INITIAL, null);
+        onView(withId(R.id.done)).check(matches(not(isDisplayed())));
+    }
+
+    @Test
+    public void signIn_withAllPlayerPreferencesSuccessfully() {
+        inputData(TEST_FIRST_NAME, TEST_LAST_INITIAL, TEST_AVATAR);
         onView(withId(R.id.done)).check(matches(isDisplayed()));
     }
 
+    @Test
     public void signIn_performSignIn() {
-        inputData();
+        inputData(TEST_FIRST_NAME, TEST_LAST_INITIAL, TEST_AVATAR);
         onView(withId(R.id.done)).perform(click());
         assertTrue(PreferencesHelper.isSignedIn(InstrumentationRegistry.getTargetContext()));
     }
@@ -98,6 +118,22 @@ public class SignInActivityTest {
         typeAndHideKeyboard(R.id.last_initial, TEST_FIRST_NAME);
         String expectedValue = String.valueOf(TEST_FIRST_NAME.charAt(0));
         onView(withId(R.id.last_initial)).check(matches(withText(expectedValue)));
+    }
+
+    private void inputData(String firstName, String lastInitial, Avatar avatar) {
+        if (firstName != null) typeAndHideKeyboard(R.id.first_name, firstName);
+        if (lastInitial != null) typeAndHideKeyboard(R.id.last_initial, lastInitial);
+        if (avatar != null) clickAvatar(avatar);
+    }
+
+    private void typeAndHideKeyboard(int targetViewId, String text) {
+        onView(withId(targetViewId)).perform(typeText(text), closeSoftKeyboard());
+    }
+
+    private void clickAvatar(Avatar avatar) {
+        onData(equalTo(avatar))
+                .inAdapterView(withId(R.id.avatars))
+                .perform(click());
     }
 
     @Test
@@ -146,14 +182,5 @@ public class SignInActivityTest {
                     .inAdapterView(withId(R.id.avatars))
                     .check(matches(matcher));
         }
-    }
-
-    private void inputData() {
-        typeAndHideKeyboard(R.id.first_name, TEST_FIRST_NAME);
-        typeAndHideKeyboard(R.id.last_initial, TEST_LAST_INITIAL);
-    }
-
-    private void typeAndHideKeyboard(int targetViewId, String text) {
-        onView(withId(targetViewId)).perform(typeText(text), closeSoftKeyboard());
     }
 }

--- a/app/src/main/java/com/google/samples/apps/topeka/fragment/SignInFragment.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/fragment/SignInFragment.java
@@ -79,8 +79,7 @@ public class SignInFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
         final View contentView = inflater.inflate(R.layout.fragment_sign_in, container, false);
-        contentView.addOnLayoutChangeListener(new View.
-                OnLayoutChangeListener() {
+        contentView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
             @Override
             public void onLayoutChange(View v, int left, int top, int right, int bottom,
                                        int oldLeft, int oldTop, int oldRight, int oldBottom) {
@@ -134,17 +133,18 @@ public class SignInFragment extends Fragment {
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
-                // showing the floating action button if text is entered
+                // hiding the floating action button if text is empty
                 if (s.length() == 0) {
                     mDoneFab.hide();
-                } else {
-                    mDoneFab.show();
                 }
             }
 
             @Override
             public void afterTextChanged(Editable s) {
-                /* no-op */
+                // showing the floating action button if avatar is selected and input data is valid
+                if (isAvatarSelected() && isInputDataValid()) {
+                    mDoneFab.show();
+                }
             }
         };
 
@@ -197,6 +197,10 @@ public class SignInFragment extends Fragment {
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 mSelectedAvatarView = view;
                 mSelectedAvatar = Avatar.values()[position];
+                // showing the floating action button if input data is valid
+                if (isInputDataValid()) {
+                    mDoneFab.show();
+                }
             }
         });
         mAvatarGrid.setNumColumns(calculateSpanCount());
@@ -204,7 +208,6 @@ public class SignInFragment extends Fragment {
             mAvatarGrid.setItemChecked(mSelectedAvatar.ordinal(), true);
         }
     }
-
 
     private void performSignInWithTransition(View v) {
         final Activity activity = getActivity();
@@ -236,6 +239,14 @@ public class SignInFragment extends Fragment {
         mPlayer = new Player(mFirstName.getText().toString(), mLastInitial.getText().toString(),
                 mSelectedAvatar);
         PreferencesHelper.writeToPreferences(activity, mPlayer);
+    }
+
+    private boolean isAvatarSelected() {
+        return mSelectedAvatarView != null || mSelectedAvatar != null;
+    }
+
+    private boolean isInputDataValid() {
+        return PreferencesHelper.isInputDataValid(mFirstName.getText(), mLastInitial.getText());
     }
 
     /**

--- a/app/src/main/java/com/google/samples/apps/topeka/helper/PreferencesHelper.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/helper/PreferencesHelper.java
@@ -18,6 +18,7 @@ package com.google.samples.apps.topeka.helper;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.text.TextUtils;
 
 import com.google.samples.apps.topeka.model.Avatar;
 import com.google.samples.apps.topeka.model.Player;
@@ -40,7 +41,7 @@ public class PreferencesHelper {
      * Writes a {@link com.google.samples.apps.topeka.model.Player} to preferences.
      *
      * @param context The Context which to obtain the SharedPreferences from.
-     * @param player The {@link com.google.samples.apps.topeka.model.Player} to write.
+     * @param player  The {@link com.google.samples.apps.topeka.model.Player} to write.
      */
     public static void writeToPreferences(Context context, Player player) {
         SharedPreferences.Editor editor = getEditor(context);
@@ -68,7 +69,7 @@ public class PreferencesHelper {
             avatar = null;
         }
 
-        if (null == firstName && null == lastInitial && null == avatar) {
+        if (null == firstName || null == lastInitial || null == avatar) {
             return null;
         }
         return new Player(firstName, lastInitial, avatar);
@@ -88,7 +89,7 @@ public class PreferencesHelper {
     }
 
     /**
-     * Check whether a user is currently signed in.
+     * Checks whether a player is currently signed in.
      *
      * @param context The context to check this in.
      * @return <code>true</code> if login data exists, else <code>false</code>.
@@ -98,6 +99,17 @@ public class PreferencesHelper {
         return preferences.contains(PREFERENCE_FIRST_NAME) &&
                 preferences.contains(PREFERENCE_LAST_INITIAL) &&
                 preferences.contains(PREFERENCE_AVATAR);
+    }
+
+    /**
+     * Checks whether the player's input data is valid.
+     *
+     * @param firstName   The player's first name to be examined.
+     * @param lastInitial The player's last initial to be examined.
+     * @return <code>true</code> if both strings are not null nor 0-length, else <code>false</code>.
+     */
+    public static boolean isInputDataValid(CharSequence firstName, CharSequence lastInitial) {
+        return !TextUtils.isEmpty(firstName) && !TextUtils.isEmpty(lastInitial);
     }
 
     private static SharedPreferences.Editor getEditor(Context context) {


### PR DESCRIPTION
This fixes #58 

Added missing Test annotation and new tests to improve SignIn behavior and avoid crashes.
Now the SignInFragment mDoneFab requires all the player preferences to be shown to pass tests.
If any player preference is missing, getPlayer method returns null.