### PR TITLE
Use the FAB view to avoid exception in transition

### DIFF
--- a/app/src/main/java/com/google/samples/apps/topeka/fragment/SignInFragment.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/fragment/SignInFragment.java
@@ -48,12 +48,11 @@ import com.google.samples.apps.topeka.model.Player;
 public class SignInFragment extends Fragment {
 
     private static final String ARG_EDIT = "EDIT";
-    private static final String KEY_SELECTED_AVATAR_INDEX = "selectedAvatarIndex";
+    private static final String KEY_AVATAR_POSITION = "avatarPosition";
     private Player mPlayer;
     private EditText mFirstName;
     private EditText mLastInitial;
-    private Avatar mSelectedAvatar;
-    private View mSelectedAvatarView;
+    private Avatar mAvatar;
     private GridView mAvatarGrid;
     private FloatingActionButton mDoneFab;
     private boolean edit;
@@ -69,9 +68,9 @@ public class SignInFragment extends Fragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
-            final int savedAvatarIndex = savedInstanceState.getInt(KEY_SELECTED_AVATAR_INDEX);
-            if (savedAvatarIndex != GridView.INVALID_POSITION) {
-                mSelectedAvatar = Avatar.values()[savedAvatarIndex];
+            final int savedAvatarPosition = savedInstanceState.getInt(KEY_AVATAR_POSITION);
+            if (savedAvatarPosition != GridView.INVALID_POSITION) {
+                mAvatar = Avatar.values()[savedAvatarPosition];
             }
         }
         super.onCreate(savedInstanceState);
@@ -95,9 +94,9 @@ public class SignInFragment extends Fragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         if (mAvatarGrid != null) {
-            outState.putInt(KEY_SELECTED_AVATAR_INDEX, mAvatarGrid.getCheckedItemPosition());
+            outState.putInt(KEY_AVATAR_POSITION, mAvatarGrid.getCheckedItemPosition());
         } else {
-            outState.putInt(KEY_SELECTED_AVATAR_INDEX, GridView.INVALID_POSITION);
+            outState.putInt(KEY_AVATAR_POSITION, GridView.INVALID_POSITION);
         }
         super.onSaveInstanceState(outState);
     }
@@ -148,7 +147,7 @@ public class SignInFragment extends Fragment {
             @Override
             public void afterTextChanged(Editable s) {
                 // showing the floating action button if avatar is selected and input data is valid
-                if (isAvatarSelected() && isInputDataValid()) {
+                if (mAvatar != null && isInputDataValid()) {
                     mDoneFab.show();
                 }
             }
@@ -168,12 +167,7 @@ public class SignInFragment extends Fragment {
                         removeDoneFab(new Runnable() {
                             @Override
                             public void run() {
-                                if (null == mSelectedAvatarView) {
-                                    performSignInWithTransition(mAvatarGrid.getChildAt(
-                                            mSelectedAvatar.ordinal()));
-                                } else {
-                                    performSignInWithTransition(mSelectedAvatarView);
-                                }
+                                performSignInWithTransition(getSharedViewForAvatarTransition());
                             }
                         });
                         break;
@@ -195,14 +189,30 @@ public class SignInFragment extends Fragment {
                 .start();
     }
 
+    /**
+     * Returns the view to be used as a shared view for the avatar transition.
+     * <p/>
+     * If the checked avatar has been scrolled out, returns the removed FAB as a last resort.
+     *
+     * @return The avatar view if it's displayed on screen, the FAB view otherwise.
+     */
+    private View getSharedViewForAvatarTransition() {
+        // child position within the adapter's data set for the avatar when is displayed on screen
+        final int childPosition = mAvatar.ordinal() - mAvatarGrid.getFirstVisiblePosition();
+        // use the FAB as the initial view during the transition when the avatar is out of view
+        if (childPosition < 0 || childPosition >= mAvatarGrid.getChildCount()) {
+            return mDoneFab;
+        }
+        return mAvatarGrid.getChildAt(childPosition);
+    }
+
     private void setUpGridView(View container) {
         mAvatarGrid = (GridView) container.findViewById(R.id.avatars);
         mAvatarGrid.setAdapter(new AvatarAdapter(getActivity()));
         mAvatarGrid.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                mSelectedAvatarView = view;
-                mSelectedAvatar = Avatar.values()[position];
+                mAvatar = Avatar.values()[position];
                 // showing the floating action button if input data is valid
                 if (isInputDataValid()) {
                     mDoneFab.show();
@@ -210,8 +220,8 @@ public class SignInFragment extends Fragment {
             }
         });
         mAvatarGrid.setNumColumns(calculateSpanCount());
-        if (mSelectedAvatar != null) {
-            mAvatarGrid.setItemChecked(mSelectedAvatar.ordinal(), true);
+        if (mAvatar != null) {
+            mAvatarGrid.setItemChecked(mAvatar.ordinal(), true);
         }
     }
 
@@ -231,7 +241,7 @@ public class SignInFragment extends Fragment {
         if (mPlayer != null) {
             mFirstName.setText(mPlayer.getFirstName());
             mLastInitial.setText(mPlayer.getLastInitial());
-            mSelectedAvatar = mPlayer.getAvatar();
+            mAvatar = mPlayer.getAvatar();
         }
     }
 
@@ -243,12 +253,8 @@ public class SignInFragment extends Fragment {
 
     private void savePlayer(Activity activity) {
         mPlayer = new Player(mFirstName.getText().toString(), mLastInitial.getText().toString(),
-                mSelectedAvatar);
+                mAvatar);
         PreferencesHelper.writeToPreferences(activity, mPlayer);
-    }
-
-    private boolean isAvatarSelected() {
-        return mSelectedAvatarView != null || mSelectedAvatar != null;
     }
 
     private boolean isInputDataValid() {

--- a/app/src/main/java/com/google/samples/apps/topeka/model/Avatar.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/model/Avatar.java
@@ -56,6 +56,6 @@ public enum Avatar {
     }
 
     public String getNameForAccessibility() {
-        return TAG + " " + ordinal() + 1;
+        return TAG + " " + (ordinal() + 1);
     }
 }


### PR DESCRIPTION
Fixes #64 

This fixes the NPE when the selected avatar view is not visible using the FAB view in that case
and fixes the GridView positions subtracting an offset to the avatar ordinal to find the correct avatar.

Renames mSelectedAvatar to mAvatar to avoid misunderstanding about selection in Android's world.

Renames  avatar index to position to avoid weird comparisons with GridView's invalid positions.

Simplifies the checked state logic removing unnecessary mSelectedAvatarView member variable.

Fixes the name for accessibility of the avatar to be used in the tests removed from this commit.

Now the contentDescription of the avatar view returns the correct avatar value, ordinal + 1, not +"1".

This could be used in Matchers to test these changes without loading views into the hierarchy (onData)
but this complicates the PR review process and the SignInActivityTest class and it's not necessary.
