### PR TITLE
Travis integration is added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: android
+
+jdk:
+ - oraclejdk8
+
+android:
+  components:
+    - platform-tools
+    - tools
+    - $ANDROID_TARGET
+    - android-23
+    - build-tools-23.0.2
+    - extra-android-m2repository
+    - sys-img-armeabi-v7a-$ANDROID_TARGET
+
+before_script:
+  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi armeabi-v7a --sdcard 200M
+  - emulator -avd test -no-audio -no-window &
+  - android-wait-for-emulator
+  - sleep 10
+  - adb shell settings put global window_animation_scale 0 &
+  - adb shell settings put global transition_animation_scale 0 &
+  - adb shell settings put global animator_duration_scale 0 &
+  - adb shell input keyevent 82 &
+
+script:
+  - ./gradlew check connectedCheck -i
+
+env:
+  global:
+    - ADB_INSTALL_TIMEOUT=8
+  matrix:
+    - ANDROID_TARGET=android-17
+    - ANDROID_TARGET=android-19
+    - ANDROID_TARGET=android-22
+
+notifications:
+  email: false
+
+sudo: required
+
+cache:
+  directories:
+    - $HOME/.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ android:
   components:
     - platform-tools
     - tools
-    - $ANDROID_TARGET
     - android-23
     - build-tools-23.0.2
     - extra-android-m2repository
@@ -32,7 +31,6 @@ env:
   matrix:
     - ANDROID_TARGET=android-17
     - ANDROID_TARGET=android-19
-    - ANDROID_TARGET=android-22
 
 notifications:
   email: false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,14 @@ android {
         }
     }
 
+    dexOptions {
+        def ci = "true".equals(System.getenv("CI"))
+        def preDexEnabled = "true".equals(System.getProperty("pre-dex", "true"))
+
+        // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
+        preDexLibraries = preDexEnabled && !ci
+    }
+
     packagingOptions {
         exclude 'LICENSE.txt'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Api Level 22 emulator is used. Marshmallow emulators have too small timeout. More info [here](https://code.google.com/p/android/issues/detail?id=189764&q=label%3APriority-Medium&colspec=ID%20Type%20Status%20Owner%20Summary%20Stars)
Build tools are updated to 1.5.0. It is because tests are more stable in 1.5.0. Not 100% necessary. I can revert it if requested. 