### PR TITLE
Changing sign_in_avatars layout in landscape mode.

### DIFF
--- a/app/src/main/res/layout-land/fragment_sign_in.xml
+++ b/app/src/main/res/layout-land/fragment_sign_in.xml
@@ -44,15 +44,13 @@
                 android:orientation="horizontal">
 
             <include
-                    layout="@layout/sign_in_username"
+                    layout="@layout/sign_in_avatars"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
-                    android:layout_marginEnd="@dimen/spacing_double"
-                    android:layout_marginRight="@dimen/spacing_double"
                     android:layout_weight="1" />
 
             <include
-                    layout="@layout/sign_in_avatars"
+                    layout="@layout/sign_in_username"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_weight="1" />

--- a/app/src/main/res/layout/sign_in_avatars.xml
+++ b/app/src/main/res/layout/sign_in_avatars.xml
@@ -39,9 +39,14 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:choiceMode="singleChoice"
+            android:clipToPadding="false"
+            android:fadeScrollbars="true"
             android:listSelector="@android:color/transparent"
-            android:verticalSpacing="@dimen/spacing_double"
+            android:paddingBottom="16dp"
             android:paddingEnd="@dimen/spacing_double"
             android:paddingStart="@dimen/spacing_double"
-            android:clipToPadding="false" />
+            android:scrollbarSize="4dp"
+            android:scrollbarThumbVertical="@color/topeka_accent"
+            android:smoothScrollbar="true"
+            android:verticalSpacing="@dimen/spacing_double"/>
 </LinearLayout>

--- a/app/src/main/res/layout/sign_in_avatars.xml
+++ b/app/src/main/res/layout/sign_in_avatars.xml
@@ -42,10 +42,10 @@
             android:clipToPadding="false"
             android:fadeScrollbars="true"
             android:listSelector="@android:color/transparent"
-            android:paddingBottom="16dp"
+            android:paddingBottom="@dimen/spacing_double"
             android:paddingEnd="@dimen/spacing_double"
             android:paddingStart="@dimen/spacing_double"
-            android:scrollbarSize="4dp"
+            android:scrollbarSize="@dimen/spacing_micro"
             android:scrollbarThumbVertical="@color/topeka_accent"
             android:smoothScrollbar="true"
             android:verticalSpacing="@dimen/spacing_double"/>


### PR DESCRIPTION
Hi,

according to scrollbars and FAB behavior  presented below:

<a href="http://pl.tinypic.com?ref=2cza735" target="_blank"><img src="http://i68.tinypic.com/2cza735.png" border="0" alt="Image and video hosting by TinyPic"></a>

I've decided to change a bit existing signing in layout to this:

<a href="http://pl.tinypic.com?ref=34tdawl" target="_blank"><img src="http://i68.tinypic.com/34tdawl.png" border="0" alt="Image and video hosting by TinyPic"></a>/a>

As you can see, I've changed order of views, deleted right margin of sign_in_username and worked a it on avatars' `GridView` layout.
