### PR TITLE
Setting visibility of mIcon as GONE if quiz has started.

### DIFF
--- a/app/src/main/java/com/google/samples/apps/topeka/activity/QuizActivity.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/activity/QuizActivity.java
@@ -164,6 +164,7 @@ public class QuizActivity extends AppCompatActivity {
             }
             findViewById(R.id.quiz_fragment_container).setVisibility(View.VISIBLE);
             mQuizFab.hide();
+            mIcon.setVisibility(View.GONE);
         } else {
             initQuizFragment();
         }


### PR DESCRIPTION
After screen rotation, `mIcon` appears like on image below:
<a href="http://pl.tinypic.com?ref=23jstoi" target="_blank"><img src="http://i64.tinypic.com/23jstoi.png" border="0" alt="Image and video hosting by TinyPic"></a>

To fix this I set `mIcon.setVisibility(View.Gone)` in `onResume() method.

Cheers
