### PR TITLE
Fix QuizActivity restore problem after recycled by system

### DIFF
--- a/app/src/main/java/com/google/samples/apps/topeka/fragment/QuizFragment.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/fragment/QuizFragment.java
@@ -162,9 +162,9 @@ public class QuizFragment extends android.support.v4.app.Fragment {
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        View focusedChild = mQuizView.getFocusedChild();
-        if (focusedChild instanceof ViewGroup) {
-            View currentView = ((ViewGroup) focusedChild).getChildAt(0);
+        View childView = mQuizView.getCurrentView();
+        if (childView instanceof ViewGroup) {
+            View currentView = ((ViewGroup) childView).getChildAt(0);
             if (currentView instanceof AbsQuizView) {
                 outState.putBundle(KEY_USER_INPUT, ((AbsQuizView) currentView).getUserInput());
             }

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/AbsQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/AbsQuizView.java
@@ -36,6 +36,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Interpolator;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.AbsListView;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -358,5 +359,17 @@ public abstract class AbsQuizView<Q extends Quiz> extends FrameLayout {
 
     private void setMinHeightInternal(View view) {
         view.setMinimumHeight(getResources().getDimensionPixelSize(R.dimen.min_height_question));
+    }
+
+    protected void setUpUserListSelection(final AbsListView listView, final int index) {
+        listView.post(new Runnable() {
+            @Override
+            public void run() {
+                listView.requestFocusFromTouch();
+                listView.performItemClick(listView.getChildAt(index), index,
+                        listView.getAdapter().getItemId(index));
+                listView.setSelection(index);
+            }
+        });
     }
 }

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/AbsQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/AbsQuizView.java
@@ -36,7 +36,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Interpolator;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.AbsListView;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -359,17 +358,5 @@ public abstract class AbsQuizView<Q extends Quiz> extends FrameLayout {
 
     private void setMinHeightInternal(View view) {
         view.setMinimumHeight(getResources().getDimensionPixelSize(R.dimen.min_height_question));
-    }
-
-    protected void setUpUserListSelection(final AbsListView listView, final int index) {
-        listView.post(new Runnable() {
-            @Override
-            public void run() {
-                listView.requestFocusFromTouch();
-                listView.performItemClick(listView.getChildAt(index), index,
-                        listView.getAdapter().getItemId(index));
-                listView.setSelection(index);
-            }
-        });
     }
 }

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/FourQuarterQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/FourQuarterQuizView.java
@@ -91,10 +91,15 @@ public class FourQuarterQuizView extends AbsQuizView<FourQuarterQuiz> {
     }
 
     private void setUpUserInput() {
-        mAnswerView.performItemClick(mAnswerView.getChildAt(mAnswered), mAnswered,
-                mAnswerView.getAdapter().getItemId(mAnswered));
-        mAnswerView.getChildAt(mAnswered).setSelected(true);
-        mAnswerView.setSelection(mAnswered);
+        mAnswerView.post(new Runnable() {
+            @Override
+            public void run() {
+                mAnswerView.requestFocusFromTouch();
+                mAnswerView.performItemClick(mAnswerView.getChildAt(mAnswered), mAnswered,
+                        mAnswerView.getAdapter().getItemId(mAnswered));
+                mAnswerView.setSelection(mAnswered);
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/FourQuarterQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/FourQuarterQuizView.java
@@ -74,7 +74,7 @@ public class FourQuarterQuizView extends AbsQuizView<FourQuarterQuiz> {
         mAnswered = savedInput.getInt(KEY_ANSWER);
         if (mAnswered != -1) {
             if (ApiLevelHelper.isAtLeast(Build.VERSION_CODES.KITKAT) && isLaidOut()) {
-                setUpUserInput();
+                setUpUserListSelection(mAnswerView, mAnswered);
             } else {
                 addOnLayoutChangeListener(new OnLayoutChangeListener() {
                     @Override
@@ -83,23 +83,11 @@ public class FourQuarterQuizView extends AbsQuizView<FourQuarterQuiz> {
                                                int oldLeft, int oldTop,
                                                int oldRight, int oldBottom) {
                         v.removeOnLayoutChangeListener(this);
-                        setUpUserInput();
+                        setUpUserListSelection(mAnswerView, mAnswered);
                     }
                 });
             }
         }
-    }
-
-    private void setUpUserInput() {
-        mAnswerView.post(new Runnable() {
-            @Override
-            public void run() {
-                mAnswerView.requestFocusFromTouch();
-                mAnswerView.performItemClick(mAnswerView.getChildAt(mAnswered), mAnswered,
-                        mAnswerView.getAdapter().getItemId(mAnswered));
-                mAnswerView.setSelection(mAnswered);
-            }
-        });
     }
 
     @Override

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/FourQuarterQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/FourQuarterQuizView.java
@@ -74,7 +74,7 @@ public class FourQuarterQuizView extends AbsQuizView<FourQuarterQuiz> {
         mAnswered = savedInput.getInt(KEY_ANSWER);
         if (mAnswered != -1) {
             if (ApiLevelHelper.isAtLeast(Build.VERSION_CODES.KITKAT) && isLaidOut()) {
-                setUpUserListSelection(mAnswerView, mAnswered);
+                setUpUserInput();
             } else {
                 addOnLayoutChangeListener(new OnLayoutChangeListener() {
                     @Override
@@ -83,11 +83,23 @@ public class FourQuarterQuizView extends AbsQuizView<FourQuarterQuiz> {
                                                int oldLeft, int oldTop,
                                                int oldRight, int oldBottom) {
                         v.removeOnLayoutChangeListener(this);
-                        setUpUserListSelection(mAnswerView, mAnswered);
+                        setUpUserInput();
                     }
                 });
             }
         }
+    }
+
+    private void setUpUserInput() {
+        mAnswerView.post(new Runnable() {
+            @Override
+            public void run() {
+                mAnswerView.requestFocusFromTouch();
+                mAnswerView.performItemClick(mAnswerView.getChildAt(mAnswered), mAnswered,
+                        mAnswerView.getAdapter().getItemId(mAnswered));
+                mAnswerView.setSelection(mAnswered);
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/MultiSelectQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/MultiSelectQuizView.java
@@ -82,8 +82,11 @@ public class MultiSelectQuizView extends AbsQuizView<MultiSelectQuiz> {
         if (null == answers) {
             return;
         }
+
         for (int i = 0; i < answers.length; i++) {
-            mListView.setItemChecked(i, answers[i]);
+            if (answers[i]) {
+                mListView.performItemClick(mListView.getChildAt(i), i, mListView.getAdapter().getItemId(i));
+            }
         }
     }
 

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/SelectItemQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/SelectItemQuizView.java
@@ -23,7 +23,6 @@ import android.util.SparseBooleanArray;
 import android.view.View;
 import android.widget.AbsListView;
 import android.widget.AdapterView;
-import android.widget.ListAdapter;
 import android.widget.ListView;
 
 import com.google.samples.apps.topeka.R;
@@ -90,19 +89,11 @@ public class SelectItemQuizView extends AbsQuizView<SelectItemQuiz> {
             return;
         }
 
-        mListView.post(new Runnable() {
-            @Override
-            public void run() {
-                final ListAdapter adapter = mListView.getAdapter();
-                for (int i = 0; i < mAnswers.length; i++) {
-                    if (mAnswers[i]) {
-                        mListView.requestFocusFromTouch();
-                        mListView.performItemClick(mListView.getChildAt(i), i, adapter.getItemId(i));
-                        mListView.setSelection(i);
-                    }
-                }
+        for (int i = 0; i < mAnswers.length; i++) {
+            if (mAnswers[i]) {
+                setUpUserListSelection(mListView, i);
             }
-        });
+        }
     }
 
     private void resetAnswer() {

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/SelectItemQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/SelectItemQuizView.java
@@ -23,6 +23,7 @@ import android.util.SparseBooleanArray;
 import android.view.View;
 import android.widget.AbsListView;
 import android.widget.AdapterView;
+import android.widget.ListAdapter;
 import android.widget.ListView;
 
 import com.google.samples.apps.topeka.R;
@@ -89,11 +90,19 @@ public class SelectItemQuizView extends AbsQuizView<SelectItemQuiz> {
             return;
         }
 
-        for (int i = 0; i < mAnswers.length; i++) {
-            if (mAnswers[i]) {
-                setUpUserListSelection(mListView, i);
+        mListView.post(new Runnable() {
+            @Override
+            public void run() {
+                final ListAdapter adapter = mListView.getAdapter();
+                for (int i = 0; i < mAnswers.length; i++) {
+                    if (mAnswers[i]) {
+                        mListView.requestFocusFromTouch();
+                        mListView.performItemClick(mListView.getChildAt(i), i, adapter.getItemId(i));
+                        mListView.setSelection(i);
+                    }
+                }
             }
-        }
+        });
     }
 
     private void resetAnswer() {

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/SelectItemQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/SelectItemQuizView.java
@@ -59,7 +59,7 @@ public class SelectItemQuizView extends AbsQuizView<SelectItemQuiz> {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 allowAnswer();
-                toggleAnswerFor(position);
+                getAnswers()[position] = true;
             }
         });
         return mListView;
@@ -88,14 +88,20 @@ public class SelectItemQuizView extends AbsQuizView<SelectItemQuiz> {
         if (mAnswers == null) {
             return;
         }
-        final ListAdapter adapter = mListView.getAdapter();
-        for (int i = 0; i < mAnswers.length; i++) {
-            mListView.performItemClick(mListView.getChildAt(i), i, adapter.getItemId(i));
-        }
-    }
 
-    private void toggleAnswerFor(int answerId) {
-        getAnswers()[answerId] = !mAnswers[answerId];
+        mListView.post(new Runnable() {
+            @Override
+            public void run() {
+                final ListAdapter adapter = mListView.getAdapter();
+                for (int i = 0; i < mAnswers.length; i++) {
+                    if (mAnswers[i]) {
+                        mListView.requestFocusFromTouch();
+                        mListView.performItemClick(mListView.getChildAt(i), i, adapter.getItemId(i));
+                        mListView.setSelection(i);
+                    }
+                }
+            }
+        });
     }
 
     private boolean[] getAnswers() {

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/SelectItemQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/SelectItemQuizView.java
@@ -59,6 +59,7 @@ public class SelectItemQuizView extends AbsQuizView<SelectItemQuiz> {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 allowAnswer();
+                resetAnswer();
                 getAnswers()[position] = true;
             }
         });
@@ -104,6 +105,14 @@ public class SelectItemQuizView extends AbsQuizView<SelectItemQuiz> {
         });
     }
 
+    private void resetAnswer() {
+        if (mAnswers != null) {
+            for (int i = 0; i < mAnswers.length; i++) {
+                mAnswers[i] = false;
+            }
+        }
+    }
+    
     private boolean[] getAnswers() {
         if (null == mAnswers) {
             mAnswers = new boolean[getQuiz().getOptions().length];

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/ToggleTranslateQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/ToggleTranslateQuizView.java
@@ -96,10 +96,20 @@ public class ToggleTranslateQuizView extends AbsQuizView<ToggleTranslateQuiz> {
             initAnswerSpace();
             return;
         }
-        ListAdapter adapter = mListView.getAdapter();
-        for (int i = 0; i < mAnswers.length; i++) {
-            mListView.performItemClick(mListView.getChildAt(i), i, adapter.getItemId(i));
-        }
+
+        mListView.post(new Runnable() {
+            @Override
+            public void run() {
+                ListAdapter adapter = mListView.getAdapter();
+                for (int i = 0; i < mAnswers.length; i++) {
+                    if (mAnswers[i]) {
+                        mListView.requestFocusFromTouch();
+                        mListView.performItemClick(mListView.getChildAt(i), i, adapter.getItemId(i));
+                        mListView.setSelection(i);
+                    }
+                }
+            }
+        });
     }
 
     private void toggleAnswerFor(int answerId) {

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/ToggleTranslateQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/ToggleTranslateQuizView.java
@@ -24,6 +24,7 @@ import android.view.View;
 import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.CompoundButton;
+import android.widget.ListAdapter;
 import android.widget.ListView;
 
 import com.google.samples.apps.topeka.R;
@@ -96,11 +97,19 @@ public class ToggleTranslateQuizView extends AbsQuizView<ToggleTranslateQuiz> {
             return;
         }
 
-        for (int i = 0; i < mAnswers.length; i++) {
-            if (mAnswers[i]) {
-                setUpUserListSelection(mListView, i);
+        mListView.post(new Runnable() {
+            @Override
+            public void run() {
+                ListAdapter adapter = mListView.getAdapter();
+                for (int i = 0; i < mAnswers.length; i++) {
+                    if (mAnswers[i]) {
+                        mListView.requestFocusFromTouch();
+                        mListView.performItemClick(mListView.getChildAt(i), i, adapter.getItemId(i));
+                        mListView.setSelection(i);
+                    }
+                }
             }
-        }
+        });
     }
 
     private void toggleAnswerFor(int answerId) {

--- a/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/ToggleTranslateQuizView.java
+++ b/app/src/main/java/com/google/samples/apps/topeka/widget/quiz/ToggleTranslateQuizView.java
@@ -24,7 +24,6 @@ import android.view.View;
 import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.CompoundButton;
-import android.widget.ListAdapter;
 import android.widget.ListView;
 
 import com.google.samples.apps.topeka.R;
@@ -97,19 +96,11 @@ public class ToggleTranslateQuizView extends AbsQuizView<ToggleTranslateQuiz> {
             return;
         }
 
-        mListView.post(new Runnable() {
-            @Override
-            public void run() {
-                ListAdapter adapter = mListView.getAdapter();
-                for (int i = 0; i < mAnswers.length; i++) {
-                    if (mAnswers[i]) {
-                        mListView.requestFocusFromTouch();
-                        mListView.performItemClick(mListView.getChildAt(i), i, adapter.getItemId(i));
-                        mListView.setSelection(i);
-                    }
-                }
+        for (int i = 0; i < mAnswers.length; i++) {
+            if (mAnswers[i]) {
+                setUpUserListSelection(mListView, i);
             }
-        });
+        }
     }
 
     private void toggleAnswerFor(int answerId) {


### PR DESCRIPTION
When at QuizActivity, If user has inputted answer and then checkout to other apps, QuizActivity may be recycled by system. Next time in, original user answer is not deplayed appropriately.